### PR TITLE
Add pack subcommand to address #4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,9 @@ shinypkg = "shinypkg.cli:app"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+    "ruff>=0.12.0",
+]

--- a/src/shinypkg/_pack.py
+++ b/src/shinypkg/_pack.py
@@ -98,8 +98,8 @@ def pack_app(source: Path, target: Path, inplace: bool = False):
                 continue
             if path.is_file() and _is_excluded(path.name):
                 continue
-            shutil.move(str(path), str(package_dir / path.name))
-            console.log(f"Moved: {package_dir / path.name}")
+            shutil.move(path, package_dir / path.name)
+            console.log(f"Moved: {path} -> {package_dir / path.name}")
 
         # context for templates
         git_info = get_git_author_info()

--- a/src/shinypkg/_pack.py
+++ b/src/shinypkg/_pack.py
@@ -79,7 +79,7 @@ def pack_app(source: Path, target: Path, inplace: bool = False):
             raise FileExistsError(f"Target directory {target} already exists.")
     else:
         if target != source:
-            raise ValueError("If inplace=False, source and target must differ.")
+            raise ValueError("If inplace=True, source and target must be the same.")
     
     # Use backup and rollback context manager
     with _backup_and_rollback(source, target, inplace):
@@ -99,7 +99,7 @@ def pack_app(source: Path, target: Path, inplace: bool = False):
             if path.is_file() and _is_excluded(path.name):
                 continue
             shutil.move(str(path), str(package_dir / path.name))
-            print(package_dir / path.name)
+            console.log(f"Moved: {package_dir / path.name}")
 
         # context for templates
         git_info = get_git_author_info()

--- a/src/shinypkg/_pack.py
+++ b/src/shinypkg/_pack.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+import fnmatch
+import shutil
+import tempfile
+from contextlib import contextmanager
+from typing import Generator, Optional
+
+from rich.console import Console
+from ._template import render_template
+from ._git import get_git_author_info
+
+console = Console()
+
+EXCLUDED_PATTERNS = [
+    "README.md",
+    "LICENSE",
+    ".gitignore",
+]
+
+def _is_excluded(file: str) -> bool:
+    return any(fnmatch.fnmatch(file, pat) for pat in EXCLUDED_PATTERNS)
+
+
+@contextmanager
+def _backup_and_rollback(source: Path, target: Path, inplace: bool) -> Generator[None, None, None]:
+    """
+    Create a backup and provide rollback functionality if the operation fails.
+    """
+    backup_dir: Optional[Path] = None
+    temp_dir_obj = None
+    target_existed = target.exists() if not inplace else False
+    
+    try:
+        if inplace:
+            # For inplace operations, create a backup of the source
+            temp_dir_obj = tempfile.TemporaryDirectory()
+            backup_dir = Path(temp_dir_obj.name) / "backup"
+            console.print("[dim]Creating backup for rollback...[/dim]")
+            shutil.copytree(source, backup_dir)
+            
+        yield
+        
+        # If we reach here, operation was successful
+        if inplace:
+            console.print("[dim]Operation successful, removing backup.[/dim]")
+            
+    except Exception as e:
+        console.print(f"[red]Operation failed: {e}[/red]")
+        console.print("[yellow]Rolling back changes...[/yellow]")
+        
+        if inplace and backup_dir and backup_dir.exists():
+            # Restore from backup
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(backup_dir, target)
+            console.print("[green]Successfully restored from backup.[/green]")
+        elif not inplace:
+            # Remove the target directory if it was created
+            if target.exists() and not target_existed:
+                shutil.rmtree(target)
+                console.print("[green]Successfully removed incomplete target directory.[/green]")
+        
+        # Re-raise the original exception
+        raise
+    finally:
+        # Clean up temporary directory
+        if temp_dir_obj:
+            temp_dir_obj.cleanup()
+
+def pack_app(source: Path, target: Path, inplace: bool = False):
+    source = source.resolve()
+    target = target.resolve()
+
+    if not source.exists():
+        raise FileNotFoundError(f"Source directory does not exist: {source}")
+  
+    if not inplace:
+        if target.exists():
+            raise FileExistsError(f"Target directory {target} already exists.")
+    else:
+        if target != source:
+            raise ValueError("If inplace=False, source and target must differ.")
+    
+    # Use backup and rollback context manager
+    with _backup_and_rollback(source, target, inplace):
+        # Initial setup
+        if not inplace:
+            shutil.copytree(source, target)
+        
+        project_name = source.name
+        package_name = project_name.replace("-", "_")
+        package_dir = target / package_name
+        package_dir.mkdir(exist_ok=True)
+
+        # Move files into the package dir
+        for path in target.iterdir():
+            if path == package_dir:
+                continue
+            if path.is_file() and _is_excluded(path.name):
+                continue
+            shutil.move(str(path), str(package_dir / path.name))
+            print(package_dir / path.name)
+
+        # context for templates
+        git_info = get_git_author_info()
+        context = {
+            "project_name": project_name,
+            "package_name": package_name,
+            "author_name": git_info["author_name"],
+            "author_email": git_info["author_email"],
+        }
+
+        # Generate template files
+        (package_dir / "__init__.py").write_text(
+            render_template("__init__.py.j2", context), encoding="utf-8"
+        )
+        (package_dir / "__main__.py").write_text(
+            render_template("__main__.py.j2", context), encoding="utf-8"
+        )
+        (target / "pyproject.toml").write_text(
+            render_template("pyproject.toml.j2", context), encoding="utf-8"
+        )
+
+        # Check for requirements.txt and return whether it exists
+        requirements_file = package_dir / "requirements.txt"
+        return requirements_file.exists()

--- a/src/shinypkg/cli.py
+++ b/src/shinypkg/cli.py
@@ -3,14 +3,14 @@
 import difflib
 import subprocess
 from pathlib import Path
-from typing import Annotated
-
+from typing import Annotated, Optional
 
 import typer
 from rich.console import Console
 
-from shinypkg._git import is_git_repo, get_git_author_info
-from shinypkg._template import render_template
+from ._git import is_git_repo, get_git_author_info
+from ._template import render_template
+from ._pack import pack_app
 
 app = typer.Typer()
 console = Console()
@@ -189,3 +189,91 @@ def upgrade(
         console.print(f"[green]Updated '{filename}' with template version.[/green]")
     else:
         console.print(f"[dim]Skipped overwriting '{filename}'.[/dim]")
+
+
+@app.command()
+def pack(
+    source: Annotated[
+        Path, typer.Argument(help="Directory of existing Shiny app")
+    ],
+    target: Annotated[
+        Optional[Path],
+        typer.Argument(help="Target directory for packaged app", show_default=False)
+    ] = None,
+    inplace: Annotated[
+        bool,
+        typer.Option("--inplace", help="Modify the source directory in-place"),
+    ] = False,
+):
+    """
+    Convert a flat Shiny app project into an installable package.
+    """
+
+    source = source.resolve()
+
+    if not source.exists():
+        console.print("[red]Error:[/red] Source directory does not exist.")
+        raise typer.Exit(1)
+
+    if target is None:
+        if inplace:
+            target = source
+        else:
+            target = source.parent / f"{source.name}-packaged"
+    else:
+        target = target.resolve()
+
+    if not inplace and target.exists():
+        console.print(f"[red]Error:[/red] Target directory {target} already exists.")
+        raise typer.Exit(1)
+
+    console.print(f"[blue]Packaging:[/blue] {source}")
+    if not inplace:
+        console.print(f"[green]Output will be written to:[/green] {target}")
+
+    try:
+        has_requirements = pack_app(source, target, inplace=inplace)
+    except Exception as e:
+        console.print(f"[red]Failed:[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print("[green]✔ Packaging complete.[/green]")
+    
+    # Check if we need to cd into the target directory
+    current_dir = Path.cwd()
+    need_cd = current_dir != target
+    
+    # Check for requirements.txt and provide installation instructions
+    project_name = source.name
+    package_name = project_name.replace("-", "_")
+    
+    if has_requirements:
+        relative_path = f"{package_name}/requirements.txt"
+        console.print("\n[blue]Found requirements.txt in the package.[/blue]")
+        console.print("To install dependencies, run:")
+        
+        if need_cd:
+            console.print(f"  [green]cd {target.name}[/green]")
+            console.print(f"  [green]uv add -r {relative_path}[/green]")
+        else:
+            console.print(f"  [green]uv add -r {relative_path}[/green]")
+            
+        console.print("\nAlternatively:")
+        if need_cd:
+            console.print(f"  [dim]cd {target.name} && pip install -r {relative_path}[/dim]")
+        else:
+            console.print(f"  [dim]pip install -r {relative_path}[/dim]")
+    else:
+        console.print("\n[dim]No requirements.txt found. You may need to manually install dependencies:[/dim]")
+        
+        if need_cd:
+            console.print(f"  [dim]cd {target.name}[/dim]")
+            console.print("  [dim]uv add shiny  # or other dependencies[/dim]")
+        else:
+            console.print("  [dim]uv add shiny  # or other dependencies[/dim]")
+    
+    # Show how to run the app after installation
+    console.print("\nTo run the app:")
+    console.print(f"  [green]uv run {project_name}[/green]")
+    console.print("\nAlternatively:")
+    console.print(f"  [dim]python -m {package_name}[/dim]")

--- a/src/shinypkg/cli.py
+++ b/src/shinypkg/cli.py
@@ -240,8 +240,7 @@ def pack(
     console.print("[green]✔ Packaging complete.[/green]")
     
     # Check if we need to cd into the target directory
-    current_dir = Path.cwd()
-    need_cd = current_dir != target
+    need_cd = Path.cwd() != target
     
     # Check for requirements.txt and provide installation instructions
     project_name = source.name

--- a/src/shinypkg/cli.py
+++ b/src/shinypkg/cli.py
@@ -240,7 +240,18 @@ def pack(
     console.print("[green]✔ Packaging complete.[/green]")
     
     # Check if we need to cd into the target directory
-    need_cd = Path.cwd() != target
+    current_dir = Path.cwd()
+    need_cd = current_dir != target
+    
+    # Calculate the path to target directory
+    target_path_str = ""
+    if need_cd:
+        try:
+            # Try to get relative path first (cleaner output)
+            target_path_str = str(target.relative_to(current_dir))
+        except ValueError:
+            # If relative path fails, use absolute path
+            target_path_str = str(target)
     
     # Check for requirements.txt and provide installation instructions
     project_name = source.name
@@ -252,21 +263,21 @@ def pack(
         console.print("To install dependencies, run:")
         
         if need_cd:
-            console.print(f"  [green]cd {target.name}[/green]")
+            console.print(f"  [green]cd {target_path_str}[/green]")
             console.print(f"  [green]uv add -r {relative_path}[/green]")
         else:
             console.print(f"  [green]uv add -r {relative_path}[/green]")
             
         console.print("\nAlternatively:")
         if need_cd:
-            console.print(f"  [dim]cd {target.name} && pip install -r {relative_path}[/dim]")
+            console.print(f"  [dim]cd {target_path_str} && pip install -r {relative_path}[/dim]")
         else:
             console.print(f"  [dim]pip install -r {relative_path}[/dim]")
     else:
         console.print("\n[dim]No requirements.txt found. You may need to manually install dependencies:[/dim]")
         
         if need_cd:
-            console.print(f"  [dim]cd {target.name}[/dim]")
+            console.print(f"  [dim]cd {target_path_str}[/dim]")
             console.print("  [dim]uv add shiny  # or other dependencies[/dim]")
         else:
             console.print("  [dim]uv add shiny  # or other dependencies[/dim]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,5 @@
-import sys
 import os
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from typer.testing import CliRunner
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,264 @@
+import sys
+import os
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from typer.testing import CliRunner
+
+from shinypkg.cli import app
+
+
+runner = CliRunner()
+
+
+def test_cli_help():
+    """Test that CLI help works"""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Packaging a shiny app made easy" in result.stdout
+
+
+def test_create_command_help():
+    """Test that create command help works"""
+    result = runner.invoke(app, ["create", "--help"])
+    assert result.exit_code == 0
+    assert "Initialize a Shiny app project" in result.stdout
+
+
+def test_pack_command_help():
+    """Test that pack command help works"""
+    result = runner.invoke(app, ["pack", "--help"])
+    assert result.exit_code == 0
+    assert "Convert a flat Shiny app project into an installable package" in result.stdout
+
+
+def test_upgrade_command_help():
+    """Test that upgrade command help works"""
+    result = runner.invoke(app, ["upgrade", "--help"])
+    assert result.exit_code == 0
+    assert "Upgrade a generated file from the template" in result.stdout
+
+
+def test_create_basic_project(tmp_path):
+    """Test creating a basic project"""
+    project_name = "testapp"
+    
+    # Change to tmp_path to create project there
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        
+        result = runner.invoke(app, [
+            "create", 
+            project_name,
+            "--author-name", "Test Author",
+            "--author-email", "test@example.com"
+        ])
+        
+        assert result.exit_code == 0
+        assert "Initialized Shiny project" in result.stdout
+        
+        # Check that project structure was created
+        project_path = tmp_path / project_name
+        package_path = project_path / project_name
+        
+        assert project_path.exists()
+        assert package_path.exists()
+        assert (package_path / "app.py").exists()
+        assert (package_path / "_util.py").exists()
+        assert (package_path / "__init__.py").exists()
+        assert (package_path / "__main__.py").exists()
+        assert (project_path / "pyproject.toml").exists()
+        assert (project_path / "README.md").exists()
+        assert (project_path / ".gitignore").exists()
+        
+        # Check pyproject.toml content
+        pyproject_content = (project_path / "pyproject.toml").read_text()
+        assert "Test Author" in pyproject_content
+        assert "test@example.com" in pyproject_content
+        assert f'name = "{project_name}"' in pyproject_content
+        
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_create_project_no_app(tmp_path):
+    """Test creating a project without sample app files"""
+    project_name = "testapp"
+    
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        
+        result = runner.invoke(app, [
+            "create", 
+            project_name,
+            "--no-app",
+            "--author-name", "Test Author",
+            "--author-email", "test@example.com"
+        ])
+        
+        assert result.exit_code == 0
+        assert "Skipping sample code generation" in result.stdout
+        
+        project_path = tmp_path / project_name
+        package_path = project_path / project_name
+        
+        # Should not have app.py and _util.py
+        assert not (package_path / "app.py").exists()
+        assert not (package_path / "_util.py").exists()
+        
+        # Should still have other files
+        assert (package_path / "__init__.py").exists()
+        assert (package_path / "__main__.py").exists()
+        assert (project_path / "pyproject.toml").exists()
+        
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_create_project_existing_directory(tmp_path):
+    """Test that create fails when directory already exists"""
+    project_name = "testapp"
+    project_path = tmp_path / project_name
+    package_path = project_path / project_name
+    
+    # Create the package directory first
+    package_path.mkdir(parents=True)
+    
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        
+        result = runner.invoke(app, [
+            "create", 
+            project_name,
+            "--author-name", "Test Author",
+            "--author-email", "test@example.com"
+        ])
+        
+        assert result.exit_code == 1
+        assert "already exists" in result.stdout
+        
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_pack_command_basic(tmp_path):
+    """Test basic pack command functionality"""
+    # Create a source app
+    source = tmp_path / "myapp"
+    source.mkdir()
+    (source / "app.py").write_text("# app.py")
+    (source / "requirements.txt").write_text("flask==2.0.0\nrequests>=2.25.0")
+    
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        
+        result = runner.invoke(app, ["pack", "myapp"])
+        
+        assert result.exit_code == 0
+        assert "Packaging complete" in result.stdout
+        assert "Found requirements.txt" in result.stdout
+        assert "uv add -r" in result.stdout
+        assert "To run the app:" in result.stdout
+        
+        # Check that packaged structure was created
+        target = tmp_path / "myapp-packaged"
+        package_dir = target / "myapp"
+        
+        assert target.exists()
+        assert package_dir.exists()
+        assert (package_dir / "app.py").exists()
+        assert (package_dir / "requirements.txt").exists()
+        assert (package_dir / "__init__.py").exists()
+        assert (package_dir / "__main__.py").exists()
+        assert (target / "pyproject.toml").exists()
+        
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_pack_command_no_requirements(tmp_path):
+    """Test pack command with no requirements.txt"""
+    # Create a source app without requirements.txt
+    source = tmp_path / "myapp"
+    source.mkdir()
+    (source / "app.py").write_text("# app.py")
+    
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        
+        result = runner.invoke(app, ["pack", "myapp"])
+        
+        assert result.exit_code == 0
+        assert "Packaging complete" in result.stdout
+        assert "No requirements.txt found" in result.stdout
+        assert "uv add shiny" in result.stdout
+        assert "To run the app:" in result.stdout
+        
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_pack_command_inplace(tmp_path):
+    """Test pack command with --inplace option"""
+    # Create a source app
+    source = tmp_path / "myapp"
+    source.mkdir()
+    (source / "app.py").write_text("# app.py")
+    
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        
+        result = runner.invoke(app, ["pack", "myapp", "--inplace"])
+        
+        assert result.exit_code == 0
+        assert "Packaging complete" in result.stdout
+        
+        # Check that files were moved within the same directory
+        package_dir = source / "myapp"
+        assert package_dir.exists()
+        assert (package_dir / "app.py").exists()
+        assert (package_dir / "__init__.py").exists()
+        assert (source / "pyproject.toml").exists()
+        
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_pack_command_nonexistent_source(tmp_path):
+    """Test pack command with non-existent source"""
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        
+        result = runner.invoke(app, ["pack", "nonexistent"])
+        
+        assert result.exit_code == 1
+        assert "Source directory does not exist" in result.stdout
+        
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_upgrade_command_nonexistent_file(tmp_path):
+    """Test upgrade command with non-existent file"""
+    # Create a basic project structure without the target file
+    project_path = tmp_path / "testproject"
+    project_path.mkdir()
+    
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(project_path)
+        
+        result = runner.invoke(app, ["upgrade", "__main__.py"])
+        
+        assert result.exit_code == 1
+        assert "not" in result.stdout.lower() and "found" in result.stdout.lower()
+        
+    finally:
+        os.chdir(original_cwd)

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -1,0 +1,229 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+
+from shinypkg._pack import pack_app, _is_excluded
+
+
+def create_dummy_app(path: Path, files: list[str]):
+    path.mkdir(parents=True, exist_ok=True)
+    for file in files:
+        (path / file).write_text(f"# {file}", encoding="utf-8")
+
+@pytest.mark.parametrize("tree", 
+                         [["app.py", "_util.py"],
+                          ["app-test.py", "foo.py", "README.md"]])
+@pytest.mark.parametrize("inplace", [False, True])
+def test_pack_into_new_directory(tmp_path, inplace, tree):
+    """
+    Ensure that pack_app correctly moves files to a package directory,
+    creating the appropriate package structure and excluding EXCLUDED files.
+    """
+    source = tmp_path / "myapp"
+    create_dummy_app(source, tree)
+
+    target = source if inplace else tmp_path / "myapp-packaged"
+
+    pack_app(source, target, inplace=inplace)
+
+    project_name = source.name
+    package_name = project_name.replace("-", "_")
+    package_dir = target / package_name
+
+    for item in tree:
+        if _is_excluded(item):
+            assert (target / item).exists()
+        else:
+            assert (package_dir / item).exists()
+            
+
+    assert (package_dir / "__main__.py").exists()
+    assert (package_dir / "__init__.py").exists()
+    assert (target / "pyproject.toml").exists()
+
+
+def test_pack_raises_on_existing_target(tmp_path):
+    source = tmp_path / "app"
+    target = tmp_path / "existing"
+    source.mkdir()
+    target.mkdir()
+    create_dummy_app(source, ["app.py", "_util.py"])
+
+    with pytest.raises(FileExistsError):
+        pack_app(source, target, inplace=False)
+
+
+def test_pack_with_requirements_txt(tmp_path):
+    """Test that pack_app correctly handles requirements.txt"""
+    source = tmp_path / "myapp"
+    create_dummy_app(source, ["app.py", "requirements.txt"])
+    
+    target = tmp_path / "myapp-packaged"
+    
+    # Should return True when requirements.txt exists
+    has_requirements = pack_app(source, target, inplace=False)
+    assert has_requirements is True
+    
+    # requirements.txt should be moved to package directory
+    package_dir = target / "myapp"
+    assert (package_dir / "requirements.txt").exists()
+    assert not (target / "requirements.txt").exists()
+
+
+def test_pack_without_requirements_txt(tmp_path):
+    """Test that pack_app correctly handles absence of requirements.txt"""
+    source = tmp_path / "myapp"
+    create_dummy_app(source, ["app.py", "_util.py"])
+    
+    target = tmp_path / "myapp-packaged"
+    
+    # Should return False when requirements.txt doesn't exist
+    has_requirements = pack_app(source, target, inplace=False)
+    assert has_requirements is False
+
+
+def test_pack_raises_on_nonexistent_source(tmp_path):
+    """Test that pack_app raises FileNotFoundError for non-existent source"""
+    source = tmp_path / "nonexistent"
+    target = tmp_path / "target"
+    
+    with pytest.raises(FileNotFoundError):
+        pack_app(source, target, inplace=False)
+
+
+def test_pack_inplace_validation(tmp_path):
+    """Test that pack_app validates inplace parameter correctly"""
+    source = tmp_path / "myapp"
+    target = tmp_path / "different"
+    create_dummy_app(source, ["app.py"])
+    
+    with pytest.raises(ValueError, match="If inplace=False, source and target must differ"):
+        pack_app(source, target, inplace=True)
+
+
+def test_excluded_files_handling(tmp_path):
+    """Test that excluded files are handled correctly"""
+    source = tmp_path / "myapp"
+    excluded_files = ["README.md", "LICENSE", ".gitignore"]
+    regular_files = ["app.py", "_util.py"]
+    all_files = excluded_files + regular_files
+    
+    create_dummy_app(source, all_files)
+    target = tmp_path / "myapp-packaged"
+    
+    pack_app(source, target, inplace=False)
+    
+    package_dir = target / "myapp"
+    
+    # Excluded files should remain at top level
+    for excluded_file in excluded_files:
+        assert (target / excluded_file).exists()
+        assert not (package_dir / excluded_file).exists()
+    
+    # Regular files should be moved to package directory
+    for regular_file in regular_files:
+        assert (package_dir / regular_file).exists()
+        assert not (target / regular_file).exists()
+
+
+def test_project_name_with_hyphens(tmp_path):
+    """Test that project names with hyphens are handled correctly"""
+    source = tmp_path / "my-app-name"
+    create_dummy_app(source, ["app.py"])
+    
+    target = tmp_path / "my-app-name-packaged"
+    
+    pack_app(source, target, inplace=False)
+    
+    # Package directory should use underscores
+    package_dir = target / "my_app_name"
+    assert package_dir.exists()
+    assert (package_dir / "app.py").exists()
+    assert (package_dir / "__init__.py").exists()
+    assert (package_dir / "__main__.py").exists()
+
+
+def test_pack_rollback_on_template_error(tmp_path):
+    """Test that pack_app rolls back when template rendering fails"""
+    source = tmp_path / "myapp"
+    create_dummy_app(source, ["app.py"])
+    
+    target = tmp_path / "myapp-packaged"
+    
+    # Mock render_template to raise an exception
+    from unittest.mock import patch
+    
+    with patch('shinypkg._pack.render_template', side_effect=Exception("Template error")):
+        with pytest.raises(Exception, match="Template error"):
+            pack_app(source, target, inplace=False)
+    
+    # Target directory should not exist after rollback
+    assert not target.exists()
+
+
+def test_pack_rollback_inplace_on_error(tmp_path):
+    """Test that pack_app rolls back inplace operations when they fail"""
+    source = tmp_path / "myapp"
+    create_dummy_app(source, ["app.py", "data.txt"])
+    
+    # Create a backup of original content for verification
+    original_files = list(source.iterdir())
+    original_content = {}
+    for file in original_files:
+        if file.is_file():
+            original_content[file.name] = file.read_text()
+    
+    # Mock render_template to raise an exception after some processing
+    from unittest.mock import patch
+    
+    with patch('shinypkg._pack.render_template', side_effect=Exception("Template error")):
+        with pytest.raises(Exception, match="Template error"):
+            pack_app(source, source, inplace=True)
+    
+    # Source should be restored to original state
+    restored_files = list(source.iterdir())
+    assert len(restored_files) == len(original_files)
+    
+    # Check that original files are restored
+    for file in restored_files:
+        if file.is_file() and file.name in original_content:
+            assert file.read_text() == original_content[file.name]
+
+
+def test_pack_rollback_preserves_existing_target(tmp_path):
+    """Test that rollback doesn't remove pre-existing target directories"""
+    source = tmp_path / "myapp"
+    create_dummy_app(source, ["app.py"])
+    
+    target = tmp_path / "existing-target"
+    target.mkdir()
+    (target / "existing-file.txt").write_text("existing content")
+    
+    # This should fail because target already exists
+    with pytest.raises(FileExistsError):
+        pack_app(source, target, inplace=False)
+    
+    # Target should still exist with original content
+    assert target.exists()
+    assert (target / "existing-file.txt").exists()
+    assert (target / "existing-file.txt").read_text() == "existing content"
+
+
+def test_pack_successful_operation_no_rollback_messages(tmp_path, capsys):
+    """Test that successful operations don't show rollback messages"""
+    source = tmp_path / "myapp"
+    create_dummy_app(source, ["app.py"])
+    
+    target = tmp_path / "myapp-packaged"
+    
+    pack_app(source, target, inplace=False)
+    
+    # Capture output
+    captured = capsys.readouterr()
+    
+    # Should not contain rollback-related messages
+    assert "Rolling back" not in captured.out
+    assert "Operation failed" not in captured.out
+    assert "restored from backup" not in captured.out

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -10,9 +10,11 @@ def create_dummy_app(path: Path, files: list[str]):
     for file in files:
         (path / file).write_text(f"# {file}", encoding="utf-8")
 
-@pytest.mark.parametrize("tree", 
-                         [["app.py", "_util.py"],
-                          ["app-test.py", "foo.py", "README.md"]])
+@pytest.mark.parametrize(
+    "tree", [
+    ["app.py", "_util.py"],
+    ["app-test.py", "foo.py", "README.md"],
+])
 @pytest.mark.parametrize("inplace", [False, True])
 def test_pack_into_new_directory(tmp_path, inplace, tree):
     """
@@ -36,7 +38,6 @@ def test_pack_into_new_directory(tmp_path, inplace, tree):
         else:
             assert (package_dir / item).exists()
             
-
     assert (package_dir / "__main__.py").exists()
     assert (package_dir / "__init__.py").exists()
     assert (target / "pyproject.toml").exists()

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -1,6 +1,4 @@
-import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import pytest
 
@@ -99,7 +97,7 @@ def test_pack_inplace_validation(tmp_path):
     target = tmp_path / "different"
     create_dummy_app(source, ["app.py"])
     
-    with pytest.raises(ValueError, match="If inplace=False, source and target must differ"):
+    with pytest.raises(ValueError, match="If inplace=True, source and target must be the same."):
         pack_app(source, target, inplace=True)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,27 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -115,12 +136,48 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]
@@ -135,6 +192,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/90/5255432602c0b196a0da6720f6f76b93eb50baef46d3c9b0025e2f9acbf3/ruff-0.12.0.tar.gz", hash = "sha256:4d047db3662418d4a848a3fdbfaf17488b34b62f527ed6f10cb8afd78135bc5c", size = 4376101, upload-time = "2025-06-17T15:19:26.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/fd/b46bb20e14b11ff49dbc74c61de352e0dc07fb650189513631f6fb5fc69f/ruff-0.12.0-py3-none-linux_armv6l.whl", hash = "sha256:5652a9ecdb308a1754d96a68827755f28d5dfb416b06f60fd9e13f26191a8848", size = 10311554, upload-time = "2025-06-17T15:18:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d3/021dde5a988fa3e25d2468d1dadeea0ae89dc4bc67d0140c6e68818a12a1/ruff-0.12.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:05ed0c914fabc602fc1f3b42c53aa219e5736cb030cdd85640c32dbc73da74a6", size = 11118435, upload-time = "2025-06-17T15:18:49.064Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a2/01a5acf495265c667686ec418f19fd5c32bcc326d4c79ac28824aecd6a32/ruff-0.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:07a7aa9b69ac3fcfda3c507916d5d1bca10821fe3797d46bad10f2c6de1edda0", size = 10466010, upload-time = "2025-06-17T15:18:51.341Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/57/7caf31dd947d72e7aa06c60ecb19c135cad871a0a8a251723088132ce801/ruff-0.12.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7731c3eec50af71597243bace7ec6104616ca56dda2b99c89935fe926bdcd48", size = 10661366, upload-time = "2025-06-17T15:18:53.29Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ba/aa393b972a782b4bc9ea121e0e358a18981980856190d7d2b6187f63e03a/ruff-0.12.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:952d0630eae628250ab1c70a7fffb641b03e6b4a2d3f3ec6c1d19b4ab6c6c807", size = 10173492, upload-time = "2025-06-17T15:18:55.262Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/50/9349ee777614bc3062fc6b038503a59b2034d09dd259daf8192f56c06720/ruff-0.12.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c021f04ea06966b02614d442e94071781c424ab8e02ec7af2f037b4c1e01cc82", size = 11761739, upload-time = "2025-06-17T15:18:58.906Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/ad459de67c70ec112e2ba7206841c8f4eb340a03ee6a5cabc159fe558b8e/ruff-0.12.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7d235618283718ee2fe14db07f954f9b2423700919dc688eacf3f8797a11315c", size = 12537098, upload-time = "2025-06-17T15:19:01.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/50/15ad9c80ebd3c4819f5bd8883e57329f538704ed57bac680d95cb6627527/ruff-0.12.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0c0758038f81beec8cc52ca22de9685b8ae7f7cc18c013ec2050012862cc9165", size = 12154122, upload-time = "2025-06-17T15:19:03.727Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/79b91e41bc8cc3e78ee95c87093c6cacfa275c786e53c9b11b9358026b3d/ruff-0.12.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:139b3d28027987b78fc8d6cfb61165447bdf3740e650b7c480744873688808c2", size = 11363374, upload-time = "2025-06-17T15:19:05.875Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c3/82b292ff8a561850934549aa9dc39e2c4e783ab3c21debe55a495ddf7827/ruff-0.12.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68853e8517b17bba004152aebd9dd77d5213e503a5f2789395b25f26acac0da4", size = 11587647, upload-time = "2025-06-17T15:19:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/42/d5760d742669f285909de1bbf50289baccb647b53e99b8a3b4f7ce1b2001/ruff-0.12.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3a9512af224b9ac4757f7010843771da6b2b0935a9e5e76bb407caa901a1a514", size = 10527284, upload-time = "2025-06-17T15:19:10.37Z" },
+    { url = "https://files.pythonhosted.org/packages/19/f6/fcee9935f25a8a8bba4adbae62495c39ef281256693962c2159e8b284c5f/ruff-0.12.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b08df3d96db798e5beb488d4df03011874aff919a97dcc2dd8539bb2be5d6a88", size = 10158609, upload-time = "2025-06-17T15:19:12.286Z" },
+    { url = "https://files.pythonhosted.org/packages/37/fb/057febf0eea07b9384787bfe197e8b3384aa05faa0d6bd844b94ceb29945/ruff-0.12.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a315992297a7435a66259073681bb0d8647a826b7a6de45c6934b2ca3a9ed51", size = 11141462, upload-time = "2025-06-17T15:19:15.195Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7c/1be8571011585914b9d23c95b15d07eec2d2303e94a03df58294bc9274d4/ruff-0.12.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e55e44e770e061f55a7dbc6e9aed47feea07731d809a3710feda2262d2d4d8a", size = 11641616, upload-time = "2025-06-17T15:19:17.6Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/b960ab4818f90ff59e571d03c3f992828d4683561095e80f9ef31f3d58b7/ruff-0.12.0-py3-none-win32.whl", hash = "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb", size = 10525289, upload-time = "2025-06-17T15:19:19.688Z" },
+    { url = "https://files.pythonhosted.org/packages/34/93/8b16034d493ef958a500f17cda3496c63a537ce9d5a6479feec9558f1695/ruff-0.12.0-py3-none-win_amd64.whl", hash = "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0", size = 11598311, upload-time = "2025-06-17T15:19:21.785Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/33/4d3e79e4a84533d6cd526bfb42c020a23256ae5e4265d858bd1287831f7d/ruff-0.12.0-py3-none-win_arm64.whl", hash = "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b", size = 10724946, upload-time = "2025-06-17T15:19:23.952Z" },
 ]
 
 [[package]]
@@ -156,11 +238,62 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "ruff", specifier = ">=0.12.0" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Add `shinypkg pack` command with rollback functionality

Closes #4

## Overview

This PR adds the `shinypkg pack` command that converts existing Shiny apps into installable Python packages.

## Key Features

### 🔧 `shinypkg pack` Command
- Converts existing Shiny app directories into package structure
- Supports `--inplace` option for in-place conversion
- Automatic detection and proper placement of requirements.txt

### 🔄 Rollback Functionality
- Automatic recovery when operations fail
- Complete backup for in-place operations
- Transactional processing to avoid incomplete states

### 📋 User Guidance
- Dependency installation instructions based on requirements.txt presence
- Support for both uv and pip
- App execution guidance

## Usage Examples

```bash
# Basic usage
shinypkg pack myapp

# In-place conversion
shinypkg pack . --inplace

# Custom target specification
shinypkg pack myapp --target myapp-dist
```

## Technical Changes

### New Files

- `src/shinypkg/_pack.py`: Core packaging logic
- `tests/test_pack.py`: Packaging functionality tests
- `tests/test_cli.py`: CLI command tests

### Key Implementations

- __Backup & Rollback__: `_backup_and_rollback` context manager for safe operations
- __File Exclusion__: Proper handling of README.md, LICENSE, .gitignore
- __Template Generation__: Automatic creation of __init__.py, __main__.py, pyproject.toml
- __Requirements Processing__: Moving requirements.txt to package directory and detection

### Test Coverage

- __27 test cases__ (increased from 5 to 27)
- Comprehensive testing of basic functionality, error cases, and rollback features
- CLI command integration tests

## Breaking Changes

None


