### PR TITLE
Fix git push in detached HEAD state for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git commit -m "Update CHANGELOG for release"
-          git push
+          git push origin HEAD:main
 
       - name: Build package
         run: python -m build


### PR DESCRIPTION
This PR fixes the git push command in the release workflow to work properly when running in detached HEAD state (when triggered by tag push).

Changes:
- Changed `git push` to `git push origin HEAD:main` to explicitly push to the main branch from detached HEAD state

This should resolve the 'You are not currently on a branch' error that was preventing the CHANGELOG.md from being committed back to the repository.