### PR TITLE
Remove CHANGELOG.md commit step to avoid branch protection conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Commit updated CHANGELOG.md
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "Update CHANGELOG for release"
-          git push origin HEAD:main
+      # Note: CHANGELOG.md is created but not committed back to avoid branch protection conflicts
+      # The changelog information is captured in the GitHub release instead
 
       - name: Build package
         run: python -m build


### PR DESCRIPTION
This PR removes the CHANGELOG.md commit step from the release workflow to avoid conflicts with branch protection rules.

The changelog information is still generated and captured in the GitHub release, but we no longer attempt to commit the CHANGELOG.md file back to the repository, which was being blocked by branch protection rules that require changes to go through pull requests.

This should allow the release workflow to complete successfully while still providing changelog functionality through GitHub releases.